### PR TITLE
[Feat] 차단 룰셋에 대한 인프라 구현

### DIFF
--- a/AD-BlockBuster/Source/Data/Repository/Endpoint/EasyListEndpoint.swift
+++ b/AD-BlockBuster/Source/Data/Repository/Endpoint/EasyListEndpoint.swift
@@ -1,0 +1,22 @@
+//
+//  EasyListEndpoint.swift
+//  AD-BlockBuster
+//
+//  Created by 정지용 on 5/15/25.
+//
+
+import Foundation
+
+enum EasyListEndpoint {
+    case easylist
+    case easyprivacy
+
+    var url: URL {
+        switch self {
+        case .easylist:
+            return URL(string: "https://easylist.to/easylist/easylist.txt")!
+        case .easyprivacy:
+            return URL(string: "https://easylist.to/easylist/easyprivacy.txt")!
+        }
+    }
+}

--- a/AD-BlockBuster/Source/Data/Repository/Endpoint/EasyListFetching.swift
+++ b/AD-BlockBuster/Source/Data/Repository/Endpoint/EasyListFetching.swift
@@ -1,0 +1,12 @@
+//
+//  EasyListFetching.swift
+//  AD-BlockBuster
+//
+//  Created by 정지용 on 5/15/25.
+//
+
+import Foundation
+
+protocol EasyListFetching {
+    func fetch(from endpoint: EasyListEndpoint) async throws -> Data
+}

--- a/AD-BlockBuster/Source/Data/Repository/Interface/BlockRuleStorage.swift
+++ b/AD-BlockBuster/Source/Data/Repository/Interface/BlockRuleStorage.swift
@@ -1,0 +1,11 @@
+//
+//  BlockRuleStorage.swift
+//  AD-BlockBuster
+//
+//  Created by 정지용 on 5/15/25.
+//
+
+protocol BlockRuleStorage {
+    func save<T: Encodable>(_ value: T, to fileName: String) throws
+    func load<T: Decodable>(_ type: T.Type, from fileName: String) throws -> T
+}

--- a/AD-BlockBuster/Source/Infrastructure/Networking/EasyListFetcher.swift
+++ b/AD-BlockBuster/Source/Infrastructure/Networking/EasyListFetcher.swift
@@ -1,0 +1,19 @@
+//
+//  EasyListFetcher.swift
+//  AD-BlockBuster
+//
+//  Created by 정지용 on 5/15/25.
+//
+
+import Foundation
+
+struct EasyListFetcher: EasyListFetching {
+    func fetch(from endpoint: EasyListEndpoint) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: endpoint.url)
+        guard let http = response as? HTTPURLResponse,
+              (200..<400).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}

--- a/AD-BlockBuster/Source/Infrastructure/Storage/AppGroupStorage.swift
+++ b/AD-BlockBuster/Source/Infrastructure/Storage/AppGroupStorage.swift
@@ -1,0 +1,32 @@
+//
+//  AppGroupStorage.swift
+//  AD-BlockBuster
+//
+//  Created by 정지용 on 5/15/25.
+//
+
+import Foundation
+
+struct AppGroupStorage: BlockRuleStorage {
+    private let containerURL: URL
+    
+    init(appGroupID: String) throws {
+        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) else {
+            // TODO: 런타임 크래시 제거
+            throw NSError(domain: "AppGroupStorage", code: 1, userInfo: nil)
+        }
+        self.containerURL = url
+    }
+    
+    func save<T>(_ value: T, to fileName: String) throws where T : Encodable {
+        let fileURL = containerURL.appendingPathComponent(fileName)
+        let data = try JSONEncoder().encode(value)
+        try data.write(to: fileURL, options: .atomic)
+    }
+    
+    func load<T: Decodable>(_ type: T.Type, from fileName: String) throws -> T {
+        let fileURL = containerURL.appendingPathComponent(fileName)
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}


### PR DESCRIPTION
## 어떤 작업을 진행하나요? 🤔
- 네트워킹 계층 구현
- 저장소 구현

## 작업 상세 내용 📝
- easylist.to로 향하는 엔드포인트, fetcher 구현
  - YAGNI 원칙에 따라, 해당 Host Application은 확장성을 고려할 가치가 낮으므로 easylist.to로 향하는 인프라만 구축
- 마찬가지로, 당장 필요한 App Group Container로 향하는 저장소만 구현
  - Content Blocker, Safari Web Extension와의 공유 컨테이너 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - EasyList 및 EasyPrivacy 목록의 데이터를 가져올 수 있는 기능이 추가되었습니다.
    - 데이터 저장 및 불러오기를 위한 추상화된 저장소 프로토콜이 도입되었습니다.
    - 앱 그룹 컨테이너 내에서 데이터를 안전하게 저장하고 불러올 수 있는 기능이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->